### PR TITLE
style: explicitly set background color for dark mode

### DIFF
--- a/renderer/styles/globals.css
+++ b/renderer/styles/globals.css
@@ -129,6 +129,11 @@
 
   body {
     @apply font-sans antialiased text-foreground;
+    background-color: #fdfcfb;
+  }
+
+  .dark body {
+    background-color: #fdfcfb;
   }
 
   #__next {


### PR DESCRIPTION
Hi there, thanks for creating this useful app.
While I'm in the dark mode of MacOS, the background of the app is semi-transparent dark grey, which makes me hard to read the content. Hence this PR.


Before:
<img width="994" height="599" alt="截屏2025-07-17 23 56 06" src="https://github.com/user-attachments/assets/d7982ec5-7021-417b-a97d-abf5dba9c69a" />

After:
<img width="997" height="598" alt="截屏2025-07-18 00 13 23" src="https://github.com/user-attachments/assets/a59ed79c-f5cc-4851-889f-f1d9cd2944b3" />




Have a good day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the background color of the app to ensure consistency across both normal and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->